### PR TITLE
Fixes deprecated DataFrame.sort() in pandas

### DIFF
--- a/traitar/hmmer2filtered_best.py
+++ b/traitar/hmmer2filtered_best.py
@@ -47,7 +47,7 @@ def aggregate_domain_hits(filtered_df, out_f):
     #sort by gene identifier and Pfam
     with open(out_f, 'w') as out_fo:
         ps.DataFrame(filtered_df.columns).T.to_csv(out_f, sep = "\t", index = False, header = False, mode = 'a')
-        filtered_df.sort(columns = ["target name", "query name"], inplace = True)
+        filtered_df.sort_values(by = ["target name", "query name"], inplace = True)
         if filtered_df.shape[0] > 0:
             current_max = filtered_df.iloc[0,] 
         else:


### PR DESCRIPTION
As of 2017-05-05, Pandas removed sort, replaced with: 

[sort values](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.sort_values.html)
and 
[sort index](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.sort_index.html)

This is due to the deprecation of sort. Given the install directions are to download the *latest* pandas, this should not have any implications on those using traitar in the future. 